### PR TITLE
Update golang.org/x/sys version to prevent crash on Mac

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,20 +2,22 @@ module github.com/robertjanetzko/LegendsBrowser2/backend
 
 go 1.18
 
-require github.com/shirou/gopsutil v3.21.11+incompatible
+require (
+	github.com/cheggaaa/pb/v3 v3.0.8
+	github.com/dustin/go-humanize v1.0.0
+	github.com/gorilla/mux v1.8.0
+	github.com/iancoleman/strcase v0.2.0
+	github.com/pkg/profile v1.6.0
+	github.com/shirou/gopsutil v3.21.11+incompatible
+)
 
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
-	github.com/cheggaaa/pb/v3 v3.0.8 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
-	github.com/pkg/profile v1.6.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,23 +2,21 @@ module github.com/robertjanetzko/LegendsBrowser2/backend
 
 go 1.18
 
-require (
-	github.com/cheggaaa/pb/v3 v3.0.8
-	github.com/dustin/go-humanize v1.0.0
-	github.com/gorilla/mux v1.8.0
-	github.com/iancoleman/strcase v0.2.0
-	github.com/pkg/profile v1.6.0
-	github.com/shirou/gopsutil v3.21.11+incompatible
-)
+require github.com/shirou/gopsutil v3.21.11+incompatible
 
 require (
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/cheggaaa/pb/v3 v3.0.8 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
+	github.com/pkg/profile v1.6.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -32,3 +32,5 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Updating to the latest version of golang.org/x/sys resolves the issue reported here: https://github.com/robertjanetzko/LegendsBrowser2/issues/1