### PR TITLE
Prevent crash on string creation for event of unknown figure drowning

### DIFF
--- a/backend/model/events.go
+++ b/backend/model/events.go
@@ -948,7 +948,10 @@ func (x *HistoricalEventHfDied) Html(c *Context) string {
 	case HistoricalEventHfDiedCause_Suffocate, HistoricalEventHfDiedCause_Air:
 		return hf + " suffocated, slain by " + slayer + loc
 	case HistoricalEventHfDiedCause_SuicideDrowned, HistoricalEventHfDiedCause_DrownAltTwo:
-		return hf + " drowned " + util.If(c.World.HistoricalFigures[x.Hfid].Female(), "herself ", "himself ") + loc
+		if f, ok := c.World.HistoricalFigures[x.Hfid]; ok {
+			return hf + " drowned " + util.If(f.Female(), "herself ", "himself ") + loc
+		}
+		return hf + " drowned themselves " + loc
 	case HistoricalEventHfDiedCause_SuicideLeaping, HistoricalEventHfDiedCause_LeaptFromHeight:
 		return hf + " leapt from a great height" + loc
 	case HistoricalEventHfDiedCause_Thirst:


### PR DESCRIPTION
This is a quick fix for https://github.com/robertjanetzko/LegendsBrowser2/issues/3, where an unknown historical figure causes a crash when trying to determine whether they are male or female.

With this fix, the event will read like this:
![Screen Shot 2022-04-29 at 1 35 25 PM](https://user-images.githubusercontent.com/3377325/166058019-a0f797de-a0e5-46c2-9915-f85ad11a2f52.png)
