### PR TITLE
Patched a bug with WrittenContent popovers and added popovers to Art Forms

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1517,6 +1517,7 @@ func NewDanceForm() *DanceForm {
 func (x *DanceForm) Id() int      { return x.Id_ }
 func (x *DanceForm) setId(id int) { x.Id_ = id }
 func (x *DanceForm) Name() string { return x.Name_ }
+func (x *DanceForm) ShortDesc() string { return util.ArtFormShortDesc(x.Name_, x.Description) }
 
 func (x *DanceForm) CheckFields() {
 }
@@ -20627,6 +20628,7 @@ func NewMusicalForm() *MusicalForm {
 func (x *MusicalForm) Id() int      { return x.Id_ }
 func (x *MusicalForm) setId(id int) { x.Id_ = id }
 func (x *MusicalForm) Name() string { return x.Name_ }
+func (x *MusicalForm) ShortDesc() string { return util.ArtFormShortDesc(x.Name_, x.Description) }
 
 func (x *MusicalForm) CheckFields() {
 }
@@ -20757,6 +20759,7 @@ func NewPoeticForm() *PoeticForm {
 func (x *PoeticForm) Id() int      { return x.Id_ }
 func (x *PoeticForm) setId(id int) { x.Id_ = id }
 func (x *PoeticForm) Name() string { return x.Name_ }
+func (x *PoeticForm) ShortDesc() string { return util.ArtFormShortDesc(x.Name_, x.Description) }
 
 func (x *PoeticForm) CheckFields() {
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -116,7 +116,7 @@ func StartServer(config *Config, world *model.DfWorld, static embed.FS) error {
 
 	srv.RegisterWorldPage("/writtencontents", "writtencontents.html", func(p Parms) any { return groupByType(srv.context.world.WrittenContents) })
 	srv.RegisterWorldResourcePage("/writtencontent/{id}", "writtencontent.html", func(id int) any { return srv.context.world.WrittenContents[id] })
-	srv.RegisterWorldResourcePage("/popover/writtencontent/{id}", "popoverWrittencontent.html", func(id int) any { return srv.context.world.WrittenContents[id] })
+	srv.RegisterWorldResourcePage("/popover/writtencontent/{id}", "popoverWrittenContent.html", func(id int) any { return srv.context.world.WrittenContents[id] })
 
 	srv.RegisterWorldPage("/hfs", "hfs.html", srv.searchHf)
 	srv.RegisterWorldResourcePage("/hf/{id}", "hf.html", func(id int) any { return srv.context.world.HistoricalFigures[id] })

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -111,8 +111,11 @@ func StartServer(config *Config, world *model.DfWorld, static embed.FS) error {
 	})
 
 	srv.RegisterWorldResourcePage("/danceform/{id}", "artform.html", func(id int) any { return srv.context.world.DanceForms[id] })
+	srv.RegisterWorldResourcePage("/popover/danceform/{id}", "popoverDanceForm.html", func(id int) any { return srv.context.world.DanceForms[id] })
 	srv.RegisterWorldResourcePage("/musicalform/{id}", "artform.html", func(id int) any { return srv.context.world.MusicalForms[id] })
+	srv.RegisterWorldResourcePage("/popover/musicalform/{id}", "popoverMusicalForm.html", func(id int) any { return srv.context.world.MusicalForms[id] })
 	srv.RegisterWorldResourcePage("/poeticform/{id}", "artform.html", func(id int) any { return srv.context.world.PoeticForms[id] })
+	srv.RegisterWorldResourcePage("/popover/poeticform/{id}", "popoverPoeticForm.html", func(id int) any { return srv.context.world.PoeticForms[id] })
 
 	srv.RegisterWorldPage("/writtencontents", "writtencontents.html", func(p Parms) any { return groupByType(srv.context.world.WrittenContents) })
 	srv.RegisterWorldResourcePage("/writtencontent/{id}", "writtencontent.html", func(id int) any { return srv.context.world.WrittenContents[id] })

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -106,7 +106,7 @@
             }).responseText;
         }
 
-        $('a.entity,a.hf,a.region,a.site,a.structure,a.worldconstruction,a.artifact,a.writtencontent,a.collection,a.landmass,a.mountain,a.identity,a.river').each(function () {
+        $('a.entity,a.hf,a.region,a.site,a.structure,a.worldconstruction,a.artifact,a.writtencontent,a.collection,a.landmass,a.mountain,a.identity,a.river,a.artform').each(function () {
             var popover = new bootstrap.Popover($(this), { content: loadLinkPopoverData, trigger: "hover", placement: "top", html: true })
         })
     </script>

--- a/backend/templates/popoverDanceForm.html
+++ b/backend/templates/popoverDanceForm.html
@@ -1,0 +1,2 @@
+{{ danceForm .Id }}<br />
+{{ .ShortDesc }}

--- a/backend/templates/popoverMusicalForm.html
+++ b/backend/templates/popoverMusicalForm.html
@@ -1,0 +1,2 @@
+{{ musicalForm .Id }}<br />
+{{ .ShortDesc }}

--- a/backend/templates/popoverPoeticForm.html
+++ b/backend/templates/popoverPoeticForm.html
@@ -1,0 +1,2 @@
+{{ poeticForm .Id }}<br />
+{{ .ShortDesc }}

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -137,3 +137,30 @@ func Strip(html template.HTML) string {
 func String(html template.HTML) string {
 	return string(html)
 }
+
+/*
+	ArtFormShortDesc
+
+	Gets a shorter description for the popovers by modifying the description data.
+
+	Note there is no way yet to highlight the
+  	author, as that info is not tracked by the XML, and would need a more
+  	intensive patch to the backend (keeping a map of art form -> author in 
+  	world context). Probably won't implement this for popovers unless I
+  	get really really bored, as it's a massive pain for minimal gain.
+*/
+func ArtFormShortDesc(name string, desc string) string {
+	if len(strings.TrimSpace(desc)) == 0 {
+		return ""
+	}
+
+	// find where the title (plus "is") ends
+	i := len(name) + 3
+
+	j := strings.Index(desc, ".")
+	if j == -1 {
+		return desc	// no period found; text is one sentence
+	}
+
+	return strings.TrimSpace(desc[i:j+1])
+}

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -162,5 +162,5 @@ func ArtFormShortDesc(name string, desc string) string {
 		return desc	// no period found; text is one sentence
 	}
 
-	return strings.TrimSpace(desc[i:j+1])
+	return strings.TrimSpace(desc[i:j])
 }


### PR DESCRIPTION
Noticed a bug with the popovers on Written Content, and went ahead and implemented popovers on Dance, Musical, and Poetic Forms while I was at it. Currently the Art Form popovers do _not_ highlight the author civilization or historical figure, as I would likely need to do something way more intensive to retain that information; it isn't kept in the XML files, sadly. Currently it trims some words from the first sentence of the Art Form's description.

### Bug Details (Fixed in PR)

When hovering over an object of the type `WrittenContent`, instead of the intended popover displaying, the server panics and logs a message to the console about `popoverWrittencontent.html` being missing; the correct file is `popoverWrittenContent.html` (with a capital 'C').

## Changelog

### Fixed WrittenContent popover bug

* **Modified**: `server/server.go` - Fixed the typo which caused the above webserver panic.

### Implemented popovers for Art Forms

* **Modified**: `model/model.go` - Added method on art form structs to get the short description; simply calls `ArtFormShortDesc()` in `util/util.go`.
* **Modified**: `server/server.go` - Added routing for new popover HTML.
* **Modified**: `templates/layout.html` - Added popover script to objects of art form type.
+ **Created**: `templates/popoverDanceForm.html` - Added popover HTML for Dance Forms
+ **Created**: `templates/popoverMusicalForm.html` - Added popover HTML for Musical Forms
+ **Created**: `templates/popoverPoeticForm.html` - Added popover HTML for Poetic Forms
* **Modified**: `util/util.go` - Added a function to get the short description for Art Forms from the XML description.